### PR TITLE
Fix GIT_DIFF_TREE_PATTERN wrt number of status letters

### DIFF
--- a/src/com/tw/go/plugin/git/GitCmdHelper.java
+++ b/src/com/tw/go/plugin/git/GitCmdHelper.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 public class GitCmdHelper extends GitHelper {
     private static final Pattern GIT_SUBMODULE_STATUS_PATTERN = Pattern.compile("^.[0-9a-fA-F]{40} (.+?)( \\(.+\\))?$");
     private static final Pattern GIT_SUBMODULE_URL_PATTERN = Pattern.compile("^submodule\\.(.+)\\.url (.+)$");
-    private static final Pattern GIT_DIFF_TREE_PATTERN = Pattern.compile("^(.{1,3})\\s+(.+)$");
+    private static final Pattern GIT_DIFF_TREE_PATTERN = Pattern.compile("^([^\\s]+)\\s+(.+)$");
 
     public GitCmdHelper(GitConfig gitConfig, File workingDir) {
         this(gitConfig, workingDir, new ProcessOutputStreamConsumer(new InMemoryConsumer()), new ProcessOutputStreamConsumer(new InMemoryConsumer()));


### PR DESCRIPTION
Hi,

we recently saw this failure in our GoCD Pipeline:

> The plugin sent a response that could not be understood by Go. Plugin returned with code '500' and the following response: '"Unable to parse git-diff-tree output line: MMMMM\tDockerfile\nFrom output:\n afc1a254a698be419299e6717a6c72c4e365ac8c\nMMMMM\tDockerfile"'

There was a similar issue reported here: https://github.com/ashwanthkumar/gocd-build-github-pull-requests/issues/123 In that case, only 3 Ms were part of the response line, in our case it's 5.

From our investigation it looks like the executed [git diff-tree](https://github.com/ashwanthkumar/git-cmd/blob/6af9b88beceb225f477e2ba06e884a7afee6e054/src/com/tw/go/plugin/git/GitCmdHelper.java#L191) command is 

```
git diff-tree --name-status --root -r -c <revision>
```

Now according to the [git documentation](https://git-scm.com/docs/git-diff-tree#_diff_format_for_merges) documentation 

> status is concatenated status characters for each parent

So if a revision has X parents, X status letters are in that line. In that case, the git pattern used [here](https://github.com/ashwanthkumar/git-cmd/blob/master/src/com/tw/go/plugin/git/GitCmdHelper.java#L23) doesn't work anymore since it only accepts up to 3 status letters.

The fix in this PRs is to group anything until the first occurance of a whitespace, then group everything following that whitespace.

Tested with some quick main method:

    public static void main(String[] args) {
        final Pattern GIT_DIFF_TREE_PATTERN = Pattern.compile("^([^\\s]+)\\s+(.+)$");

        final String[] resultLines = new String[]{
            "M\tsrc/main/resources/policies/local/ccassetreview-hoolihan-event-policy-local.json",
            "MMM\tapp/xxx/src/main/webapp/xxxx/xxx.jsp",
            "MMMMM\tDockerfile",
        };

        for(String resultLine : resultLines) {
        Matcher m = GIT_DIFF_TREE_PATTERN.matcher(resultLine);
        if (!m.find()) {
            throw new RuntimeException(String.format("Unable to parse git-diff-tree output line: %s%nFrom output:%n %s", resultLine, String.join(System.lineSeparator())));
        }
        System.err.println(String.format("%s : %s", m.group(1), m.group(2)));
        }
    }






